### PR TITLE
Speed up the `clear` operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ delete bonjour          time:   [5.3178 µs 5.3269 µs 5.3371 µs]
 delete hola             time:   [5.3025 µs 5.3150 µs 5.3295 µs]
 delete oi               time:   [5.2892 µs 5.2959 µs 5.3029 µs]
 delete mulimuta         time:   [5.2611 µs 5.2701 µs 5.2788 µs]
-clear                   time:   [7.0131 ms 7.0549 ms 7.1265 ms]
+clear                   time:   [99.167 µs 99.881 µs 100.80 µs]
 ```
 
 ## Acknowledgement

--- a/benches/scdb.rs
+++ b/benches/scdb.rs
@@ -128,10 +128,10 @@ fn get_updates() -> Vec<(Vec<u8>, Vec<u8>)> {
 
 criterion_group!(
     benches,
-    // setting_benchmark,
-    // updating_benchmark,
-    // getting_benchmark,
-    // deleting_benchmark,
+    setting_benchmark,
+    updating_benchmark,
+    getting_benchmark,
+    deleting_benchmark,
     clearing_benchmark
 );
 criterion_main!(benches);

--- a/benches/scdb.rs
+++ b/benches/scdb.rs
@@ -128,10 +128,10 @@ fn get_updates() -> Vec<(Vec<u8>, Vec<u8>)> {
 
 criterion_group!(
     benches,
-    setting_benchmark,
-    updating_benchmark,
-    getting_benchmark,
-    deleting_benchmark,
+    // setting_benchmark,
+    // updating_benchmark,
+    // getting_benchmark,
+    // deleting_benchmark,
     clearing_benchmark
 );
 criterion_main!(benches);

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -154,19 +154,17 @@ No read, nor write would be allowed. It can also be requested for by the user.
 
 Clear the entire database.
 
-1. Create new file
-2. Copy header into the new file and reset file_size
-3. Add an empty index to the file
-4. Clear the buffers
-5. Delete the old file
-6. Rename the new file to the old file's name
+1. Initialize a new header basing on the old settings
+2. Write the new header into the file
+3. Shrink the file to the size of the header
+4. Expand the file to the expected size of file if it had headers and index blocks. This fills any gaps with 0s.
 
 ##### Performance
 
 - Time complexity: This operation is O(1) where k is the `number_of_index_blocks` and N is the number of keys in the
   file before
   compaction.
-- Auxiliary space: This operation is O(km) where k is the `number_of_index_blocks` and m is the `block_size`.
+- Auxiliary space: This operation is O(m) where m is the size of the header i.e. 100.
 
 ### Optimizations
 


### PR DESCRIPTION
## What was Done

- Optimized the `clear` operation by using `set_len` to shrink and expand the file instead of manually copying in the index blocks, one at a time. This made the code 70 times faster, bringing the operation into the microsecond range.