### PR TITLE
Make searching optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.2.0] - 2023-01-16
+
+### Added
+
+### Changed
+
+- Changed the `Store::new()` signature, replacing `max_index_key_len` option with `is_search_enabled`.
+- Permanently set the maximum index key length to 3
+- Changed benchmarks to compare operations when search is enabled to when search is disabled.
+- Enhanced accuracy of benchmarks for the `delete`, and `set` operations.
+
+### Fixed
+
 ## [0.1.2] - 2023-01-12
 
 ### Added
@@ -15,7 +28,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Bumped `clokwerk` to version 0.4 to fix [Seg fault in the time package](https://github.com/sopherapps/py_scdb/security/dependabot/2)
+- Bumped `clokwerk` to version 0.4 to
+  fix [Seg fault in the time package](https://github.com/sopherapps/py_scdb/security/dependabot/2)
 
 
 ## [0.1.1] - 2023-01-12
@@ -37,7 +51,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Changed the `Store::new()` signature to include `max_search_index_key_length` option.
+- Changed the `Store::new()` signature to include `max_index_key_len` option.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scdb"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 license-file = "LICENSE"
 repository = "https://github.com/sopherapps/scdb"

--- a/benches/scdb.rs
+++ b/benches/scdb.rs
@@ -8,94 +8,112 @@ use scdb::Store;
 const STORE_PATH: &str = "testdb";
 
 // Setting
-fn setting_without_ttl_benchmark(c: &mut Criterion) {
-    let mut store = Store::new(STORE_PATH, None, None, None, Some(0), None).expect("create store");
-    store.clear().expect("clear store");
-    let records = get_records();
-    for (k, v) in &records {
-        let k = k.clone();
-        let v = v.clone();
-        c.bench_function(
-            &format!("set(no ttl): '{}'", String::from_utf8(k.clone()).unwrap(),),
-            |b| b.iter_with_large_drop(|| store.set(black_box(&k), black_box(&v), black_box(None))),
-        );
-    }
-}
-
-fn setting_with_ttl_benchmark(c: &mut Criterion) {
-    let mut store = Store::new(STORE_PATH, None, None, None, Some(0), None).expect("create store");
+fn setting_without_search_benchmark(c: &mut Criterion) {
+    let mut store = Store::new(STORE_PATH, None, None, None, Some(0), false).expect("create store");
     store.clear().expect("clear store");
     let ttl = Some(3_600u64);
-    let records = get_records();
-    for (k, v) in &records {
-        let k = k.clone();
-        let v = v.clone();
-        c.bench_function(
-            &format!("set(ttl): '{}'", String::from_utf8(k.clone()).unwrap(),),
-            |b| b.iter_with_large_drop(|| store.set(black_box(&k), black_box(&v), black_box(ttl))),
-        );
-    }
+    let (k, v) = (b"foo".to_vec(), b"bar".to_vec());
+
+    c.bench_function(
+        &format!("set(no ttl): '{}'", String::from_utf8(k.clone()).unwrap(),),
+        |b| b.iter_with_large_drop(|| store.set(black_box(&k), black_box(&v), black_box(None))),
+    );
+
+    c.bench_function(
+        &format!("set(ttl): '{}'", String::from_utf8(k.clone()).unwrap(),),
+        |b| b.iter_with_large_drop(|| store.set(black_box(&k), black_box(&v), black_box(ttl))),
+    );
+}
+
+fn setting_with_search_benchmark(c: &mut Criterion) {
+    let mut store = Store::new(STORE_PATH, None, None, None, Some(0), true).expect("create store");
+    store.clear().expect("clear store");
+    let ttl = Some(3_600u64);
+    let (k, v) = (b"foo".to_vec(), b"bar".to_vec());
+
+    c.bench_function(
+        &format!(
+            "set(no ttl) with search: '{}'",
+            String::from_utf8(k.clone()).unwrap(),
+        ),
+        |b| b.iter_with_large_drop(|| store.set(black_box(&k), black_box(&v), black_box(None))),
+    );
+
+    c.bench_function(
+        &format!(
+            "set(ttl) with search: '{}'",
+            String::from_utf8(k.clone()).unwrap(),
+        ),
+        |b| b.iter_with_large_drop(|| store.set(black_box(&k), black_box(&v), black_box(ttl))),
+    );
 }
 
 // Updating
-fn updating_without_ttl_benchmark(c: &mut Criterion) {
-    let mut store = Store::new(STORE_PATH, None, None, None, Some(0), None).expect("create store");
+fn updating_without_search_benchmark(c: &mut Criterion) {
+    let mut store = Store::new(STORE_PATH, None, None, None, Some(0), false).expect("create store");
     store.clear().expect("clear store");
-    let records = get_records();
-    let updates = get_updates();
-    for (k, v) in &records {
-        store.set(k, v, None).expect(&format!("set {:?}", k));
-    }
-    for (k, v) in &updates {
-        c.bench_function(
-            &format!(
-                "update(no ttl): '{}'",
-                String::from_utf8(k.clone()).unwrap(),
-            ),
-            |b| b.iter_with_large_drop(|| store.set(black_box(k), black_box(v), black_box(None))),
-        );
-    }
+    let ttl = Some(3_600u64);
+    let (k1, v1) = (b"foo".to_vec(), b"bar".to_vec());
+    let (k2, v2) = (b"fenecans".to_vec(), b"barracks".to_vec());
+
+    store.set(&k1, &v1, None).expect(&format!("set {:?}", k1));
+    c.bench_function(
+        &format!(
+            "update(no ttl): '{}'",
+            String::from_utf8(k1.clone()).unwrap(),
+        ),
+        |b| b.iter_with_large_drop(|| store.set(black_box(&k2), black_box(&v2), black_box(None))),
+    );
+
+    store.set(&k1, &v1, ttl).expect(&format!("set {:?}", k1));
+    c.bench_function(
+        &format!("update(ttl): '{}'", String::from_utf8(k2.clone()).unwrap(),),
+        |b| b.iter_with_large_drop(|| store.set(black_box(&k2), black_box(&v2), black_box(ttl))),
+    );
 }
 
-fn updating_with_ttl_benchmark(c: &mut Criterion) {
-    let mut store = Store::new(STORE_PATH, None, None, None, Some(0), None).expect("create store");
+fn updating_with_search_benchmark(c: &mut Criterion) {
+    let mut store = Store::new(STORE_PATH, None, None, None, Some(0), true).expect("create store");
     store.clear().expect("clear store");
-    let records = get_records();
-    let updates = get_updates();
     let ttl = Some(3_600u64);
-    for (k, v) in &records {
-        store.set(k, v, ttl).expect(&format!("set {:?}", k));
-    }
-    for (k, v) in &updates {
-        c.bench_function(
-            &format!("update(ttl): '{}'", String::from_utf8(k.clone()).unwrap(),),
-            |b| b.iter_with_large_drop(|| store.set(black_box(k), black_box(v), black_box(ttl))),
-        );
-    }
+    let (k1, v1) = (b"foo".to_vec(), b"bar".to_vec());
+    let (k2, v2) = (b"fenecans".to_vec(), b"barracks".to_vec());
+
+    store.set(&k1, &v1, None).expect(&format!("set {:?}", k1));
+    c.bench_function(
+        &format!(
+            "update(no ttl) with search: '{}'",
+            String::from_utf8(k1.clone()).unwrap(),
+        ),
+        |b| b.iter_with_large_drop(|| store.set(black_box(&k2), black_box(&v2), black_box(None))),
+    );
+
+    store.set(&k1, &v1, ttl).expect(&format!("set {:?}", k1));
+    c.bench_function(
+        &format!(
+            "update(ttl) with search: '{}'",
+            String::from_utf8(k2.clone()).unwrap(),
+        ),
+        |b| b.iter_with_large_drop(|| store.set(black_box(&k2), black_box(&v2), black_box(ttl))),
+    );
 }
 
 // Getting
-fn getting_without_ttl_benchmark(c: &mut Criterion) {
-    let mut store = Store::new(STORE_PATH, None, None, None, Some(0), None).expect("create store");
+fn getting_without_search_benchmark(c: &mut Criterion) {
+    let mut store = Store::new(STORE_PATH, None, None, None, Some(0), false).expect("create store");
     store.clear().expect("clear store");
+    let ttl = Some(3_600u64);
     let records = get_records();
+
     for (k, v) in &records {
         store.set(k, v, None).expect(&format!("set {:?}", k));
     }
-
     for (k, _) in &records {
         c.bench_function(
             &format!("get(no ttl): '{}'", String::from_utf8(k.clone()).unwrap()),
             |b| b.iter_with_large_drop(|| store.get(black_box(k))),
         );
     }
-}
-
-fn getting_with_ttl_benchmark(c: &mut Criterion) {
-    let mut store = Store::new(STORE_PATH, None, None, None, Some(0), None).expect("create store");
-    store.clear().expect("clear store");
-    let records = get_records();
-    let ttl = Some(3_600u64);
 
     for (k, v) in &records {
         store.set(k, v, ttl).expect(&format!("set {:?}", k));
@@ -108,9 +126,42 @@ fn getting_with_ttl_benchmark(c: &mut Criterion) {
     }
 }
 
+fn getting_with_search_benchmark(c: &mut Criterion) {
+    let mut store = Store::new(STORE_PATH, None, None, None, Some(0), true).expect("create store");
+    store.clear().expect("clear store");
+    let ttl = Some(3_600u64);
+    let records = get_records();
+
+    for (k, v) in &records {
+        store.set(k, v, None).expect(&format!("set {:?}", k));
+    }
+    for (k, _) in &records {
+        c.bench_function(
+            &format!(
+                "get(no ttl) with search: '{}'",
+                String::from_utf8(k.clone()).unwrap()
+            ),
+            |b| b.iter_with_large_drop(|| store.get(black_box(k))),
+        );
+    }
+
+    for (k, v) in &records {
+        store.set(k, v, ttl).expect(&format!("set {:?}", k));
+    }
+    for (k, _) in &records {
+        c.bench_function(
+            &format!(
+                "get(with ttl) without search: '{}'",
+                String::from_utf8(k.clone()).unwrap()
+            ),
+            |b| b.iter_with_large_drop(|| store.get(black_box(k))),
+        );
+    }
+}
+
 // Searching
 fn searching_without_pagination_benchmark(c: &mut Criterion) {
-    let mut store = Store::new(STORE_PATH, None, None, None, Some(0), None).expect("create store");
+    let mut store = Store::new(STORE_PATH, None, None, None, Some(0), true).expect("create store");
     store.clear().expect("clear store");
     let records = get_records();
     for (k, v) in &records {
@@ -132,7 +183,7 @@ fn searching_without_pagination_benchmark(c: &mut Criterion) {
 }
 
 fn searching_with_pagination_benchmark(c: &mut Criterion) {
-    let mut store = Store::new(STORE_PATH, None, None, None, Some(0), None).expect("create store");
+    let mut store = Store::new(STORE_PATH, None, None, None, Some(0), true).expect("create store");
     store.clear().expect("clear store");
     let records = get_records();
     for (k, v) in &records {
@@ -154,76 +205,114 @@ fn searching_with_pagination_benchmark(c: &mut Criterion) {
 }
 
 // Deleting
-fn deleting_without_ttl_benchmark(c: &mut Criterion) {
-    let records = get_records();
-    let mut store = Store::new(STORE_PATH, None, None, None, Some(0), None).expect("create store");
-    store.clear().expect("clear store");
-    for (k, v) in &records {
-        store.set(k, v, None).expect(&format!("set {:?}", k));
-    }
-
-    for (k, _) in &records {
-        c.bench_function(
-            &format!(
-                "delete(no ttl): '{}'",
-                String::from_utf8(k.clone()).unwrap()
-            ),
-            |b| b.iter(|| store.delete(black_box(k))),
-        );
-    }
-}
-
-fn deleting_with_ttl_benchmark(c: &mut Criterion) {
-    let records = get_records();
+fn deleting_benchmark(c: &mut Criterion) {
     let ttl = Some(3_600u64);
-    let mut store = Store::new(STORE_PATH, None, None, None, Some(0), None).expect("create store");
-    store.clear().expect("clear store");
-    for (k, v) in &records {
-        store.set(k, v, ttl).expect(&format!("set {:?}", k));
-    }
+    let (k, v) = (b"foo".to_vec(), b"bar".to_vec());
 
-    for (k, _) in &records {
-        c.bench_function(
-            &format!("delete(ttl): '{}'", String::from_utf8(k.clone()).unwrap()),
-            |b| b.iter(|| store.delete(black_box(k))),
-        );
-    }
+    let prep = |ttl: Option<u64>, is_with_search: bool| {
+        let mut store = Store::new(STORE_PATH, None, None, None, Some(0), is_with_search)
+            .expect("create store");
+
+        store.set(&k, &v, ttl).expect(&format!("set {:?}", k));
+        store
+    };
+
+    c.bench_function(
+        &format!(
+            "delete(no ttl): '{}'",
+            String::from_utf8(k.clone()).unwrap()
+        ),
+        |b| {
+            b.iter_batched(
+                || prep(None, false),
+                |mut store| store.delete(black_box(&k)),
+                BatchSize::PerIteration,
+            )
+        },
+    );
+
+    c.bench_function(
+        &format!("delete(ttl): '{}'", String::from_utf8(k.clone()).unwrap()),
+        |b| {
+            b.iter_batched(
+                || prep(ttl, false),
+                |mut store| store.delete(black_box(&k)),
+                BatchSize::PerIteration,
+            )
+        },
+    );
+
+    c.bench_function(
+        &format!(
+            "delete(no ttl) with search: '{}'",
+            String::from_utf8(k.clone()).unwrap()
+        ),
+        |b| {
+            b.iter_batched(
+                || prep(None, true),
+                |mut store| store.delete(black_box(&k)),
+                BatchSize::PerIteration,
+            )
+        },
+    );
+
+    c.bench_function(
+        &format!(
+            "delete(ttl) with search: '{}'",
+            String::from_utf8(k.clone()).unwrap()
+        ),
+        |b| {
+            b.iter_batched(
+                || prep(ttl, true),
+                |mut store| store.delete(black_box(&k)),
+                BatchSize::PerIteration,
+            )
+        },
+    );
 }
 
 // Clearing
-fn clearing_without_ttl_benchmark(c: &mut Criterion) {
+fn clearing_benchmark(c: &mut Criterion) {
+    let ttl = Some(3_600u64);
+
+    let prep = |ttl: Option<u64>, is_with_search: bool| {
+        let mut store = Store::new(STORE_PATH, None, None, None, Some(0), is_with_search)
+            .expect("create store");
+        store.clear().expect("clear store");
+        let records = get_records();
+        for (k, v) in &records {
+            store.set(k, v, ttl).expect(&format!("set {:?}", k));
+        }
+        store
+    };
+
     c.bench_function("clear(no ttl)", |b| {
         b.iter_batched(
-            || {
-                let mut store =
-                    Store::new(STORE_PATH, None, None, None, Some(0), None).expect("create store");
-                store.clear().expect("clear store");
-                let records = get_records();
-                for (k, v) in &records {
-                    store.set(k, v, None).expect(&format!("set {:?}", k));
-                }
-                store
-            },
+            || prep(None, false),
             |mut store| store.clear(),
             BatchSize::PerIteration,
         )
     });
-}
 
-fn clearing_with_ttl_benchmark(c: &mut Criterion) {
     c.bench_function("clear(ttl)", |b| {
         b.iter_batched(
-            || {
-                let mut store =
-                    Store::new(STORE_PATH, None, None, None, Some(0), None).expect("create store");
-                store.clear().expect("clear store");
-                let records = get_records();
-                let ttl = Some(3_600u64);
-                for (k, v) in &records {
-                    store.set(k, v, ttl).expect(&format!("set {:?}", k));
-                }
-                store
-            },
+            || prep(ttl, false),
+            |mut store| store.clear(),
+            BatchSize::PerIteration,
+        )
+    });
+
+    c.bench_function("clear(no ttl) with search", |b| {
+        b.iter_batched(
+            || prep(None, true),
+            |mut store| store.clear(),
+            BatchSize::PerIteration,
+        )
+    });
+
+    c.bench_function("clear(ttl) with search", |b| {
+        b.iter_batched(
+            || prep(ttl, true),
             |mut store| store.clear(),
             BatchSize::PerIteration,
         )
@@ -232,22 +321,40 @@ fn clearing_with_ttl_benchmark(c: &mut Criterion) {
 
 // Compacting
 fn compacting_benchmark(c: &mut Criterion) {
-    let mut store = Store::new(STORE_PATH, None, None, None, Some(0), None).expect("create store");
-    store.clear().expect("clear store");
-    let records = get_records();
-    for (k, v) in &records[..3] {
-        store.set(k, v, Some(1)).expect(&format!("set {:?}", k));
-    }
+    let prep = |is_with_search: bool| {
+        let mut store = Store::new(STORE_PATH, None, None, None, Some(0), is_with_search)
+            .expect("create store");
+        store.clear().expect("clear store");
+        let records = get_records();
+        for (k, v) in &records[..3] {
+            store.set(k, v, Some(1)).expect(&format!("set {:?}", k));
+        }
 
-    for (k, v) in &records[3..] {
-        store.set(k, v, None).expect(&format!("set {:?}", k));
-    }
+        for (k, v) in &records[3..] {
+            store.set(k, v, None).expect(&format!("set {:?}", k));
+        }
 
-    for (k, _) in &records[2..3] {
-        store.delete(k).expect(&format!("delete {:?}", k));
-    }
+        for (k, _) in &records[2..3] {
+            store.delete(k).expect(&format!("delete {:?}", k));
+        }
+        store
+    };
 
-    c.bench_function("compact", |b| b.iter(|| store.compact()));
+    c.bench_function("compact", |b| {
+        b.iter_batched(
+            || prep(false),
+            |mut store| store.compact(),
+            BatchSize::PerIteration,
+        )
+    });
+
+    c.bench_function("compact with search", |b| {
+        b.iter_batched(
+            || prep(true),
+            |mut store| store.compact(),
+            BatchSize::PerIteration,
+        )
+    });
 }
 
 fn get_records() -> Vec<(Vec<u8>, Vec<u8>)> {
@@ -265,33 +372,18 @@ fn get_records() -> Vec<(Vec<u8>, Vec<u8>)> {
     .collect()
 }
 
-fn get_updates() -> Vec<(Vec<u8>, Vec<u8>)> {
-    [
-        ("hey", "Jane"),
-        ("hi", "John"),
-        ("hola", "Santos"),
-        ("oi", "Ronaldo"),
-        ("mulimuta", "Aliguma"),
-    ]
-    .into_iter()
-    .map(|(k, v)| (k.to_string().into_bytes(), v.to_string().into_bytes()))
-    .collect()
-}
-
 criterion_group!(
     benches,
-    setting_without_ttl_benchmark,
-    setting_with_ttl_benchmark,
-    updating_without_ttl_benchmark,
-    updating_with_ttl_benchmark,
-    getting_without_ttl_benchmark,
-    getting_with_ttl_benchmark,
+    setting_without_search_benchmark,
+    setting_with_search_benchmark,
+    updating_without_search_benchmark,
+    updating_with_search_benchmark,
+    getting_without_search_benchmark,
+    getting_with_search_benchmark,
     searching_without_pagination_benchmark,
     searching_with_pagination_benchmark,
-    deleting_without_ttl_benchmark,
-    deleting_with_ttl_benchmark,
-    clearing_without_ttl_benchmark,
-    clearing_with_ttl_benchmark,
+    deleting_benchmark,
+    clearing_benchmark,
     compacting_benchmark,
 );
 criterion_main!(benches);

--- a/examples/hello_scdb.rs
+++ b/examples/hello_scdb.rs
@@ -31,7 +31,7 @@ fn main() {
     // One very important config is `max_keys`. With it, you can limit the store size to a number of keys.
     // By default, the limit is 1 million keys
     let mut store =
-        Store::new("db", Some(1000), Some(1), Some(10), Some(1800), Some(3)).expect("create store");
+        Store::new("db", Some(1000), Some(1), Some(10), Some(1800), true).expect("create store");
     let records = [
         ("hey", "English"),
         ("hi", "English"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,8 @@ Of course to make it a little more appealing, it has some extra features like:
 
 - Time-to-live (TTL) where a key-value pair expires after a given time.
   Useful when used as a cache.
+- Searching for keys beginning with a given subsequence. [`is_search_enabled` param of `scdb::new()` must be true.]
+  Note: **Enabling searching makes `set`, `delete`, `clear` and `compact` slower than if it were disabled.**
 - Non-blocking reads from separate processes, and threads.
   Useful in multithreaded applications
 - Fast Sequential writes to the store, queueing any writes from multiple processes and threads.
@@ -47,7 +49,8 @@ Next:
                             Some(1), // `redundant_blocks`
                             Some(10), // `pool_capacity`
                             Some(1800), // `compaction_interval`
-                            Some(3))?; // `max_index_key_len`
+                            true)?; // `is_search_enabled` (if true, set, clear and delete
+                                    // are slower)
     let key = b"foo";
     let value = b"bar";
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -744,6 +744,20 @@ mod tests {
 
     #[test]
     #[serial]
+    fn search_errs_when_disabled() {
+        let mut store =
+            Store::new(STORE_PATH, None, None, None, Some(0), false).expect("create store");
+        store.clear().expect("store failed to clear");
+        let keys = to_byte_arrays_vector!(["foo", "fore", "bar", "band", "pig"]);
+        let values = to_byte_arrays_vector!(["eng", "span", "port", "nyoro", "dan"]);
+
+        insert_test_data(&mut store, &keys, &values, None);
+        assert!(store.search(&b"f".to_vec(), 0, 0).is_err());
+        fs::remove_dir_all(STORE_PATH).expect("delete store folder");
+    }
+
+    #[test]
+    #[serial]
     fn search_works() {
         let mut store =
             Store::new(STORE_PATH, None, None, None, Some(0), true).expect("create store");


### PR DESCRIPTION
### Why

Having the searching functionality enabled by default slows down all mutative operations i.e. `set`, `delete`, `clear`, `compact` by non-trivial margins. 
However, there are times when searching is not necessary. Why pay the cost for it when you don't need it?
Let's make it optional by replacing `max_index_key_len` parameter of `scdb::Store::new()` with `is_search_enabled`.

Also, having the user decide the maximum size of the keys (`max_index_key_len`) in the inverted index is unnecessary as for most usable cases, `3` seems enough.

### What was Done

- Changed the `Store::new()` signature, replacing `max_index_key_len` option with `is_search_enabled`.
- Permanently set the maximum index key length to 3
- Changed benchmarks to compare operations when search is enabled to when search is disabled.
- Enhanced accuracy of benchmarks for the `delete`, and `set` operations.